### PR TITLE
21 update unit price formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'responders'
 gem 'bcrypt', '~> 3.1.7'
+gem 'active_model_serializers', github: 'rails-api/active_model_serializers'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/rails-api/active_model_serializers.git
+  revision: 532828b4dad41e1f5b17fe29751bb693b4bc0da2
+  specs:
+    active_model_serializers (0.10.0.rc4)
+      actionpack (>= 4.0)
+      activemodel (>= 4.0)
+      railties (>= 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -194,6 +203,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers!
   bcrypt (~> 3.1.7)
   byebug
   capybara

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,2 +1,3 @@
 class InvoiceItem < ActiveRecord::Base
 end
+

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,0 +1,13 @@
+class InvoiceItemSerializer < ActiveModel::Serializer
+  attributes :id,
+             :item_id,
+             :invoice_id,
+             :quantity,
+             :unit_price,
+             :created_at,
+             :updated_at
+
+  def unit_price
+    self.object.unit_price.to_f / 100
+  end
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,14 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id,
+             :name,
+             :description,
+             :unit_price,
+             :merchant_id,
+             :created_at,
+             :updated_at
+
+  def unit_price
+    self.object.unit_price.to_f / 100
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,16 @@ Rails.application.routes.draw do
       resources :items,         only: [:index, :show], defaults: { format: 'json' }
       resources :merchants,     only: [:index, :show], defaults: { format: 'json' }
       resources :transactions,  only: [:index, :show], defaults: { format: 'json' }
+
+      # resources :transactions do
+      #   resources :comments, only:
+      #   get '/find' => '/find#show'
+      #   get '/find_all' => '/find#index'
+      #
+      # end
+      # 
+
+
     end
   end
 end

--- a/spec/requests/api/v1/invoice_items_spec.rb
+++ b/spec/requests/api/v1/invoice_items_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "InvoiceItems API" do
     expect(json.last['item_id']).to eq(ii_7.item_id)
     expect(json.last['invoice_id']).to eq(ii_7.invoice_id)
     expect(json.last['quantity']).to eq(ii_7.quantity)
-		expect(json.last['unit_price']).to eq(ii_7.unit_price)
+		expect(json.last['unit_price']).to eq(ii_7.unit_price.to_f/100)
 
   end
 
@@ -33,7 +33,7 @@ RSpec.describe "InvoiceItems API" do
     expect(json['item_id']).to eq(ii_2.item_id)
     expect(json['invoice_id']).to eq(ii_2.invoice_id)
     expect(json['quantity']).to eq(ii_2.quantity)
-		expect(json['unit_price']).to eq(ii_2.unit_price)
+		expect(json['unit_price']).to eq(ii_2.unit_price.to_f/100)
 	end
 
   it 'sends details on invoice item when passed ID as param' do
@@ -44,7 +44,7 @@ RSpec.describe "InvoiceItems API" do
     expect(json['item_id']).to eq(ii_2.item_id)
     expect(json['invoice_id']).to eq(ii_2.invoice_id)
     expect(json['quantity']).to eq(ii_2.quantity)
-		expect(json['unit_price']).to eq(ii_2.unit_price)
+		expect(json['unit_price']).to eq(ii_2.unit_price.to_f/100)
 	end
 
   it 'sends details on first matching invoice when passed ITEM_ID as param' do
@@ -55,7 +55,7 @@ RSpec.describe "InvoiceItems API" do
     expect(json['item_id']).to eq(ii_2.item_id)
     expect(json['invoice_id']).to eq(ii_2.invoice_id)
     expect(json['quantity']).to eq(ii_2.quantity)
-		expect(json['unit_price']).to eq(ii_2.unit_price)
+		expect(json['unit_price']).to eq(ii_2.unit_price.to_f/100)
   end
 
 	it 'sends details on all matching invoices when passed ITEM_ID as param' do
@@ -75,7 +75,7 @@ RSpec.describe "InvoiceItems API" do
 		expect(json['item_id']).to eq(ii_1.item_id)
 		expect(json['invoice_id']).to eq(ii_1.invoice_id)
 		expect(json['quantity']).to eq(ii_1.quantity)
-		expect(json['unit_price']).to eq(ii_1.unit_price)
+		expect(json['unit_price']).to eq(ii_1.unit_price.to_f/100)
 	end
 
 	it 'sends details on all matching invoices when passed INVOICE_ID as param' do
@@ -95,7 +95,7 @@ RSpec.describe "InvoiceItems API" do
 		expect(json['item_id']).to eq(ii_1.item_id)
 		expect(json['invoice_id']).to eq(ii_1.invoice_id)
 		expect(json['quantity']).to eq(ii_1.quantity)
-		expect(json['unit_price']).to eq(ii_1.unit_price)
+		expect(json['unit_price']).to eq(ii_1.unit_price.to_f/100)
 	end
 
 	it 'sends details on all matching invoices when passed QUANTITY as param' do
@@ -114,7 +114,7 @@ RSpec.describe "InvoiceItems API" do
 		expect(json['item_id']).to eq(ii_2.item_id)
 		expect(json['invoice_id']).to eq(ii_2.invoice_id)
 		expect(json['quantity']).to eq(ii_2.quantity)
-		expect(json['unit_price']).to eq(ii_2.unit_price)
+		expect(json['unit_price']).to eq(ii_2.unit_price.to_f/100)
 	end
 
 	it 'sends details on all matching invoices when passed UNIT_PRICE as param' do
@@ -134,6 +134,6 @@ RSpec.describe "InvoiceItems API" do
 		expect(json['item_id']).to eq(ii_random.item_id)
 		expect(json['invoice_id']).to eq(ii_random.invoice_id)
 		expect(json['quantity']).to eq(ii_random.quantity)
-		expect(json['unit_price']).to eq(ii_random.unit_price)
+		expect(json['unit_price']).to eq(ii_random.unit_price.to_f/100)
   end
 end

--- a/spec/requests/api/v1/items_spec.rb
+++ b/spec/requests/api/v1/items_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Items API" do
     expect(json.length).to eq(3)
     expect(json.last['name']).to eq(i_3.name)
     expect(json.last['description']).to eq(i_3.description)
-    expect(json.last['unit_price']).to eq(i_3.unit_price)
+    expect(json.last['unit_price']).to eq(i_3.unit_price.to_f/100)
 		expect(json.last['merchant_id']).to eq(i_3.merchant_id)
   end
 
@@ -25,7 +25,7 @@ RSpec.describe "Items API" do
 		expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
 	end
 
@@ -36,7 +36,7 @@ RSpec.describe "Items API" do
 		expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
 	end
 
@@ -47,7 +47,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
   end
 
@@ -61,7 +61,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to_not eq(i_5.id)
 		expect(json['name']).to eq(i_4.name)
     expect(json['description']).to eq(i_4.description)
-    expect(json['unit_price']).to eq(i_4.unit_price)
+    expect(json['unit_price']).to eq(i_4.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_4.merchant_id)
   end
 
@@ -72,7 +72,7 @@ RSpec.describe "Items API" do
 		expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
 	end
 
@@ -100,7 +100,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
   end
 
@@ -114,7 +114,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to_not eq(i_5.id)
 		expect(json['name']).to eq(i_4.name)
     expect(json['description']).to eq(i_4.description)
-    expect(json['unit_price']).to eq(i_4.unit_price)
+    expect(json['unit_price']).to eq(i_4.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_4.merchant_id)
   end
 
@@ -125,7 +125,7 @@ RSpec.describe "Items API" do
 		expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
 	end
 
@@ -146,7 +146,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to eq(i_4.id)
 		expect(json['name']).to eq(i_4.name)
     expect(json['description']).to eq(i_4.description)
-    expect(json['unit_price']).to eq(i_4.unit_price)
+    expect(json['unit_price']).to eq(i_4.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_4.merchant_id)
   end
 
@@ -157,7 +157,7 @@ RSpec.describe "Items API" do
     expect(response).to be_success
     expect(json["id"]).to eq(i_4.id)
   end
-  
+
 	it 'sends details on transaction when passed UNIT_PRICE as param' do
 		get "/api/v1/items/find?unit_price=#{i_2.unit_price}"
 
@@ -165,7 +165,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
   end
 
@@ -179,7 +179,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to_not eq(i_5.id)
 		expect(json['name']).to eq(i_4.name)
     expect(json['description']).to eq(i_4.description)
-    expect(json['unit_price']).to eq(i_4.unit_price)
+    expect(json['unit_price']).to eq(i_4.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_4.merchant_id)
   end
 
@@ -199,7 +199,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to eq(i_2.id)
 		expect(json['name']).to eq(i_2.name)
     expect(json['description']).to eq(i_2.description)
-    expect(json['unit_price']).to eq(i_2.unit_price)
+    expect(json['unit_price']).to eq(i_2.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_2.merchant_id)
   end
 
@@ -213,7 +213,7 @@ RSpec.describe "Items API" do
     expect(json["id"]).to_not eq(i_5.id)
 		expect(json['name']).to eq(i_4.name)
     expect(json['description']).to eq(i_4.description)
-    expect(json['unit_price']).to eq(i_4.unit_price)
+    expect(json['unit_price']).to eq(i_4.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_4.merchant_id)
   end
 
@@ -234,7 +234,7 @@ RSpec.describe "Items API" do
 		expect(response).to be_success
 		expect(json['name']).to eq(i_random.name)
     expect(json['description']).to eq(i_random.description)
-    expect(json['unit_price']).to eq(i_random.unit_price)
+    expect(json['unit_price']).to eq(i_random.unit_price.to_f/100)
 		expect(json['merchant_id']).to eq(i_random.merchant_id)
 	end
 end


### PR DESCRIPTION
Closes #21 

This retains the unit_price integer format in the database, but converts from cents to dollars when presenting the API. 
